### PR TITLE
bump to 1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-citadel VERSION 1.0.0)
+project(ignition-citadel VERSION 1.0.1)
 
 #============================================================================
 # Find ignition-cmake


### PR DESCRIPTION
Make a patch release of `ign-citadel` since it's tagged release still has references to bitbucket in the yaml file:

* https://github.com/ignitionrobotics/ign-citadel/compare/ignition-citadel_1.0.0...main

I'd like to test https://github.com/ignition-tooling/release-tools/pull/313 with this release.