### PR TITLE
Bump dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,18 +18,19 @@ ign_configure_project()
 
 # all list of citadel packages
 
-ign_find_package(ignition-common3 REQUIRED)
-ign_find_package(ignition-fuel_tools4 REQUIRED)
-ign_find_package(ignition-gazebo3 REQUIRED)
-ign_find_package(ignition-gui3 REQUIRED)
+ign_find_package(ignition-common3 REQUIRED VERSION 3.4)
+ign_find_package(ignition-fuel_tools4 REQUIRED VERSION 4.1)
+ign_find_package(ignition-gazebo3 REQUIRED VERSION 3.3)
+ign_find_package(ignition-gui3 REQUIRED VERSION 3.1)
 ign_find_package(ignition-launch2 REQUIRED)
-ign_find_package(ignition-math6 REQUIRED)
-ign_find_package(ignition-msgs5 REQUIRED)
+ign_find_package(ignition-math6 REQUIRED VERSION 6.6)
+ign_find_package(ignition-msgs5 REQUIRED VERSION 5.3)
+ign_find_package(ignition-physics2 REQUIRED VERSION 2.3)
 ign_find_package(ignition-plugin1 REQUIRED)
-ign_find_package(ignition-physics2 REQUIRED)
+ign_find_package(ignition-rendering3 REQUIRED VERSION 3.1)
 ign_find_package(ignition-sensors3 REQUIRED)
 ign_find_package(ignition-tools REQUIRED)
 ign_find_package(ignition-transport8 REQUIRED)
-
+ign_find_package(sdformat9 REQUIRED VERSION 9.2.0)
 
 install(DIRECTORY gazebodistro DESTINATION ${IGN_DATA_INSTALL_DIR})


### PR DESCRIPTION
Update to minimum dependencies needed by `ign-gazebo3.3`:

https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo3/CMakeLists.txt

The goal is to make sure all dependencies are updated together. Otherwise, if a leaf library is updated without its dependencies, there may be API / ABI incompatibilities.

The `-release` repo also needs to be updated.